### PR TITLE
Fix GUI theme initialization

### DIFF
--- a/file_search_engine.py
+++ b/file_search_engine.py
@@ -10,7 +10,11 @@ import os
 import pickle
 import PySimpleGUI as sg
 from typing import Dict
-sg.ChangeLookAndFeel('Black')
+
+# The older API used `ChangeLookAndFeel` which is no longer available in
+# current versions of PySimpleGUI. Use the supported `change_look_and_feel`
+# call instead so that the program works with modern releases.
+sg.change_look_and_feel('Black')
 
 class Gui:
     ''' Create a GUI object '''


### PR DESCRIPTION
## Summary
- use current `change_look_and_feel` API to apply PySimpleGUI theme

## Testing
- `python3 -m py_compile file_search_engine.py file_search_engine_listbox.py`

------
https://chatgpt.com/codex/tasks/task_e_686235cc6ad483228ca1551360a93132