### PR TITLE
Enable interactive results selection

### DIFF
--- a/file_search_engine.py
+++ b/file_search_engine.py
@@ -21,19 +21,20 @@ class Gui:
     
     def __init__(self):
         self.layout: list = [
-            [sg.Text('Search Term', size=(11,1)), 
-             sg.Input(size=(40,1), focus=True, key="TERM"), 
-             sg.Radio('Contains', size=(10,1), group_id='choice', key="CONTAINS", default=True), 
-             sg.Radio('StartsWith', size=(10,1), group_id='choice', key="STARTSWITH"), 
+            [sg.Text('Search Term', size=(11,1)),
+             sg.Input(size=(40,1), focus=True, key="TERM"),
+             sg.Radio('Contains', size=(10,1), group_id='choice', key="CONTAINS", default=True),
+             sg.Radio('StartsWith', size=(10,1), group_id='choice', key="STARTSWITH"),
              sg.Radio('EndsWith', size=(10,1), group_id='choice', key="ENDSWITH")],
-            [sg.Text('Root Path', size=(11,1)), 
-             sg.Input('/..', size=(40,1), key="PATH"), 
-             sg.FolderBrowse('Browse', size=(10,1)), 
-             sg.Button('Re-Index', size=(10,1), key="_INDEX_"), 
+            [sg.Text('Root Path', size=(11,1)),
+             sg.Input('/..', size=(40,1), key="PATH"),
+             sg.FolderBrowse('Browse', size=(10,1)),
+             sg.Button('Re-Index', size=(10,1), key="_INDEX_"),
              sg.Button('Search', size=(10,1), bind_return_key=True, key="_SEARCH_")],
-            [sg.Output(size=(100,30))]]
-        
-        self.window: object = sg.Window('File Search Engine', self.layout, element_justification='left')
+            [sg.Listbox(values=[], size=(100,30), key="_RESULTS_", enable_events=True)]]
+
+        self.window: object = sg.Window('File Search Engine', self.layout, element_justification='left', finalize=True)
+        self.window['_RESULTS_'].expand(expand_x=True, expand_y=True)
 
 
 class SearchEngine:
@@ -92,6 +93,11 @@ class SearchEngine:
             for row in self.results:
                 f.write(row + '\n')
 
+
+def open_file(file_name: str) -> None:
+    """Attempt to open the file with the default program"""
+    os.system(file_name)
+
 def main():
     ''' The main loop for the program '''
     g = Gui()
@@ -110,15 +116,15 @@ def main():
             print()
         if event == '_SEARCH_':
             s.search(values)
+            g.window['_RESULTS_'].update(values=s.results)
 
-            # print the results to output element
-            print()
-            for result in s.results:
-                print(result)
-            
             print()
             print(">> Searched {:,d} records and found {:,d} matches".format(s.records, s.matches))
             print(">> Results saved in working directory as search_results.txt.")
+        if event == '_RESULTS_':
+            result_list = values.get('_RESULTS_', [])
+            if result_list:
+                open_file(result_list[0])
 
 
 if __name__ == '__main__':

--- a/tests/test_open_file_event.py
+++ b/tests/test_open_file_event.py
@@ -1,0 +1,39 @@
+import types
+import sys
+from unittest.mock import MagicMock, patch
+
+ROOT = __import__('pathlib').Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# create a minimal PySimpleGUI stub
+mock_sg = types.ModuleType('PySimpleGUI')
+mock_sg.change_look_and_feel = lambda *a, **k: None
+mock_sg.Text = lambda *a, **k: None
+mock_sg.Input = lambda *a, **k: None
+mock_sg.Radio = lambda *a, **k: None
+mock_sg.FolderBrowse = lambda *a, **k: None
+mock_sg.Button = lambda *a, **k: None
+mock_sg.Listbox = lambda *a, **k: None
+sys.modules['PySimpleGUI'] = mock_sg
+
+import file_search_engine
+
+class DummyWindow:
+    def __init__(self):
+        self.read = MagicMock(side_effect=[
+            ('_RESULTS_', {'_RESULTS_': ['foo']}),
+            (None, None),
+        ])
+    def __getitem__(self, key):
+        return MagicMock(update=MagicMock())
+
+
+def test_open_file_called():
+    window = DummyWindow()
+    gui = MagicMock()
+    gui.window = window
+    with patch.object(file_search_engine, 'Gui', return_value=gui), \
+         patch.object(file_search_engine.SearchEngine, 'load_existing_index'), \
+         patch('file_search_engine.open_file') as mock_open:
+        file_search_engine.main()
+        mock_open.assert_called_once_with('foo')

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(ROOT))
 
 mock_sg = types.ModuleType('PySimpleGUI')
 mock_sg.ChangeLookAndFeel = lambda *args, **kwargs: None
+mock_sg.change_look_and_feel = lambda *args, **kwargs: None
 sys.modules['PySimpleGUI'] = mock_sg
 from file_search_engine import SearchEngine
 


### PR DESCRIPTION
## Summary
- show search results in a selectable listbox
- open selected file using a new `open_file` helper
- patch PySimpleGUI stub in tests
- add unit test verifying `open_file` usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68624ff11390832293033333705de105